### PR TITLE
Update Caddy image components

### DIFF
--- a/stacks/caddy/Dockerfile
+++ b/stacks/caddy/Dockerfile
@@ -4,9 +4,9 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOTOOLCHAIN=auto xcaddy build \
-    --with github.com/greenpau/caddy-security@v1.1.31 \
-    --with github.com/caddy-dns/cloudflare@v0.2.2 \
-    --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.10.0
+    --with github.com/greenpau/caddy-security@v1.1.64 \
+    --with github.com/caddy-dns/cloudflare@v0.2.4 \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.13.1
 
 FROM caddy:2.11.4
 


### PR DESCRIPTION
## Summary

- Update caddy-security from v1.1.31 to v1.1.64.
- Update the Cloudflare DNS provider from v0.2.2 to v0.2.4.
- Update caddy-docker-proxy from v2.10.0 to v2.13.1.
- Keep the Caddy base image at v2.11.4, which is current and matches the updated security and Docker proxy modules.

## Why

The custom Caddy image was behind on its bundled modules. These updates bring current fixes and security improvements relevant to certificate provisioning and Docker label discovery.

## Validation

- Verified the exact upstream tags from the public Git repositories.
- Confirmed caddy-security v1.1.64 and caddy-docker-proxy v2.13.1 declare compatibility with Caddy v2.11.4.
- Ran `git diff --check`.
- The local Docker daemon is unavailable, so the multi-architecture image build is left to the repository GitHub Actions workflow.
